### PR TITLE
Intranet - anchor-content too narrow when not using sticky links MM - 3078

### DIFF
--- a/intranet.scss
+++ b/intranet.scss
@@ -657,6 +657,10 @@ footer.footer {
         border-bottom: 1px solid #000;
     }
 
+// 3078 - myNet adding jumplinks makes body container too narrow
+body:not(.body--sticky-jumplinks) #anchor-contents {
+    width: auto;
+}
 
 
 @media (max-width: 1300px)


### PR DESCRIPTION
Intranet - anchor-content too narrow when not using sticky links MM - 3078