### PR TITLE
All sites - Calendar 'sticky' dates white background / squashed cards between 768px & 780px - 4745

### DIFF
--- a/global/_bookings.scss
+++ b/global/_bookings.scss
@@ -146,7 +146,8 @@
   border-radius: 15px;
 }
 
-@include mq(md, max) {
+
+@media (max-width:780px) { //4745 - @include mq(md, max) 
   .calendar-date--selected.calendar-date--sticky {
     top: 0px !important;
   }
@@ -210,7 +211,7 @@
   margin-top: 10px;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 780px) { //4745
   .calendar__week,
   .calendar__row,
   .calendar__row--dates,
@@ -490,3 +491,16 @@
 .booking-summary__terms{
   display: flex;
 }
+
+
+/***** 4745 - Calendar 'sticky' dates on scroll - add white background *****
+
+     This extends a white section from the days of the week row (.calendar__week) behind the number date row (.calendar__row--dates) so that when the menu is sticky
+     the bookable cards do not peek in between the gaps of the numbered dates row.  But we only want to show this when the the menus are sticky because otherwise 
+     when you scroll down the white section will overlap the footer.  Well done for following this far :-)
+*/
+.calendar:has(.calendar__row--sticky) .calendar__controls--sticky ~ .calendar__week--sticky {
+  box-shadow: 0px 90px 0px 23px #FFFFFF;
+  z-index: 1; 
+}
+


### PR DESCRIPTION
All sites - Calendar 'sticky' dates white background / squashed cards between 768px & 780px - 4745