### PR TITLE
Global: Parallax panel - background image skips/resizes when scrolling on mobile (Android) - 4959

### DIFF
--- a/global/_panels.scss
+++ b/global/_panels.scss
@@ -2864,3 +2864,13 @@ h4.stage-link__title  {
 .a-panel--display-image-rounded.a-panel--formsservice .a-panel__content .gi-responsiveimage__image {
   border-radius: $rounded-corner-border-radius;
 }
+
+/*======================================================================================
+4959 Parallax panel - background image skips/resizes when scrolling on mobile (Android)
+======================================================================================*/
+
+@media (max-width: 768px) {
+  .a-panel--pt.a-panel--hasbackground {
+    background-attachment: scroll; 
+  }
+}


### PR DESCRIPTION
Global: Parallax panel - background image skips/resizes when scrolling on mobile (Android) - 4959